### PR TITLE
Add googler

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 
 ### Games
 
-- [Angband](http://rephial.org/) - Angband is a free, single-player dungeon exploration game. 
+- [Angband](http://rephial.org/) - Angband is a free, single-player dungeon exploration game.
 - [Cataclysm: Dark Days Ahead](http://en.cataclysmdda.com/) - Roguelike set in a post-apocalyptic world.
 - [Curse of War](https://a-nikolaev.github.io/curseofwar/) - Fast-paced real-time action strategy game.
 - [Frotz](http://frotz.sourceforge.net/) - Interpreter for Infocom games and other Z-machine games.
@@ -311,6 +311,7 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 
 - [ELinks](http://elinks.or.cz) - Advanced and well-established feature-rich text mode web (HTTP/FTP/..) browser.
 - [GoAccess](https://www.goaccess.io) - Real-time visual web log analyzer and interactive viewer.
+- [googler](https://github.com/jarun/googler) - Google Search, Google Site Search, Google News from the terminal.
 - [pageres](https://github.com/sindresorhus/pageres) - Capture screenshots of websites in various resolutions.
 
 


### PR DESCRIPTION
googler is a power tool to Google (Web & News) and Google Site Search from the command-line.
Features:

- Google Search, Google Site Search, Google News
- Fast and clean (no ads, stray URLs or clutter), custom color
- Navigate result pages from omniprompt, open URLs in browser
- Effortless keyword-based site search with googler @t add-on
- Fetch n results in a go, start at the n<sup>th</sup> result
- Disable automatic spelling correction and search exact keywords
- Specify duration, country/domain (default: worldwide/.com), language
- Google keywords (e.g. `filetype:mime`, `site:somesite.com`) support
- Open the first result directly in browser (as in *I'm Feeling Lucky*)
- Non-stop searches: fire new searches at omniprompt without exiting
- HTTPS proxy, User Agent, TLS 1.2 (default) support
- Man page with examples, completion scripts for Bash, Zsh and Fish
- Minimal dependencies