### PR TITLE
Replace OptiPNG with Oxipng

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 - [Ncdu](https://dev.yorhel.nl/ncdu) - Disk usage analyzer with an ncurses interface.
 - [ranger](http://ranger.nongnu.org/) - Minimalistic visual file manager featuring curses interface with VI key bindings.
 - [vifm](http://vifm.info) - ncurses based file manager with vi like keybindings/modes/options/commands/configuration, which also borrows some useful ideas from mutt.
-- [zfsnap](http://www.zfsnap.org/) - Rolling ZFS snapshots the easy way. 
+- [zfsnap](http://www.zfsnap.org/) - Rolling ZFS snapshots the easy way.
 
 ### FTP
 
@@ -190,7 +190,7 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 - [Legofy](https://github.com/JuanPotato/Legofy) - Python program that takes a static image or gif and makes it so that it looks as if it was built out of LEGO.
 - [MKVToolNix](https://mkvtoolnix.download/) - A set of tools to create, alter and inspect Matroska files under Linux, other Unices and Windows.
 - [MediaInfo](http://mediaarea.net/en/MediaInfo) - Convenient unified display of the most relevant technical and tag data for video and audio files.
-- [OptiPNG](http://optipng.sourceforge.net) - PNG optimizer that recompresses image files to a smaller size, without losing any information.
+- [Oxipng](https://github.com/shssoichiro/oxipng) - Multi-threaded PNG optimizer that recompresses image files to a smaller size, without losing any information.
 - [Pngcrush](http://pmt.sourceforge.net/pngcrush/) - An optimizer for PNG (Portable Network Graphics) files.
 - [Shellpic](https://github.com/larsjsol/shellpic) - Display images inline in the shell, ASCII-art is so 2013.
 - [Video Transcoding Scripts](https://github.com/donmelton/video-transcoding-scripts) - Utilities to transcode, inspect and convert videos.


### PR DESCRIPTION
Oxipng is a multi-threaded PNG optimizer written in Rust. It can be used as a drop-in replacement for OptiPNG in most cases.