### PR TITLE
Added Rebound: a command-line debugger powered by Stack Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 
 ### Developer
 
-- [Rebound](https://github.com/shobrook/rebound) - Instantly fetch Stack Overflow results when you get a compiler error.
 - [Cookiecutter](https://github.com/audreyr/cookiecutter) - Command-line utility that creates projects from cookiecutters (project templates).
 - [Critical](https://github.com/addyosmani/critical) - Extract & Inline Critical-path CSS in HTML pages.
 - [Grunt](http://gruntjs.com) - The JavaScript Task Runner.
 - [HTTPie](https://github.com/jkbrzt/httpie) - User-friendly cURL replacement featuring intuitive UI, JSON support, syntax highlighting, wget-like downloads, extensions, etc.
 - [Publoy](http://abhiomkar.github.io/publoy/) - Command line tool to deploy your static webapps via Dropbox.
+- [Rebound](https://github.com/shobrook/rebound) - Instantly fetch Stack Overflow results when you get a compiler error.
 - [Yarn](https://yarnpkg.com) - Deterministic, secure alternative to npm.
 - [bat](https://github.com/astaxie/bat) - Go implement CLI, cURL-like tool for humans.
 - [bcal](https://github.com/jarun/bcal) - Byte CALculator for storage conversions and calculations.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If you want to contribute, you are highly encouraged to do so. Please read the [
 
 ### Developer
 
+- [Rebound](https://github.com/shobrook/rebound) - Instantly fetch Stack Overflow results when you get a compiler error.
 - [Cookiecutter](https://github.com/audreyr/cookiecutter) - Command-line utility that creates projects from cookiecutters (project templates).
 - [Critical](https://github.com/addyosmani/critical) - Extract & Inline Critical-path CSS in HTML pages.
 - [Grunt](http://gruntjs.com) - The JavaScript Task Runner.


### PR DESCRIPTION
I recently built Rebound, a command-line tool that instantly fetches Stack Overflow results when you get a compiler error. It's a pretty useful tool for any developer, so I thought I'd add it to the list. Check it out here: https://github.com/shobrook/rebound/