### PR TITLE
Add dnote to the "Productivity" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Patreon: https://www.patreon.com/herrbischoff
 - [Timetrap](https://github.com/samg/timetrap) - Simple command line timetracker.
 - [Watson](http://tailordev.github.io/Watson/) - Elegant time tracking with a CLI.
 - [woof](http://www.home.unix-ag.org/simon/woof.html) - Simple one-off HTTP file sharing.
+- [dnote](https://github.com/dnote/dnote) - A simple and end-to-end encrypted notebook to keep users focused.
 
 ### RSS
 


### PR DESCRIPTION
This PR adds [dnote](https://github.com/dnote/dnote) to the "Productivity" section. Dnote is a free and open source note-taking software and it is relevant because it keeps the users focused by minimizing environment switching.