### PR TITLE
Added cbf

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Patreon: https://www.patreon.com/herrbischoff
 - [bcal](https://github.com/jarun/bcal) - Byte CALculator for storage conversions and calculations.
 - [bitwise](https://github.com/mellowcandle/bitwise) - Terminal based interactive bit manipulator in curses.
 - [caniuse-cmd](https://github.com/sgentle/caniuse-cmd) - All the power of caniuse.com with none of the GUI.
+- [cbf](https://github.com/joshuatvernon/cbf) - Build custom CLI apps with only a json or yaml file.
 - [clog](https://github.com/kentcdodds/clog-cli) - A conventional changelog for the rest of us.
 - [Cookiecutter](https://github.com/audreyr/cookiecutter) - Command-line utility that creates projects from cookiecutters (project templates).
 - [Critical](https://github.com/addyosmani/critical) - Extract & Inline Critical-path CSS in HTML pages.


### PR DESCRIPTION
Added cbf a CLI app for creating custom CLI apps. Very meta but very powerful. It allows developers to define how a CLI app should behave by just writing a simple json or yaml script. It can also automatically turn any package.json scripts section into a CLI app.