### PR TITLE
Add sqlline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ When you find something helpful in here, you could buy me a coffee. I spend a lo
 
 - [mycli](http://mycli.net) - Command line interface for MySQL, MariaDB, and Percona with auto-completion and syntax highlighting.
 - [pgcli](http://pgcli.com) - Command line interface for Postgres with auto-completion and syntax highlighting.
+- [sqlline](https://github.com/julianhyde/sqlline) - Shell for issuing SQL via JDBC.
 
 ### Data Processing
 


### PR DESCRIPTION
**New App Submission**

**App name:**
sqlline
**Repo or homepage link:**
https://github.com/julianhyde/sqlline
**Description:**
Shell for issuing SQL to relational databases via JDBC

Currently it has more than 250 stars and continues growing. It could connect to any db via jdbc driver and not only db (e.g. it could connect to elastic-search, cassandra, splunk, mongo, kafka via apache calcite). It provides autocompletion, syntax highlighting, multiline editing(emacs/vi modes), dialect supports.
Besides project Readme.md there is also a set of video demos with that at asciinema.org https://github.com/julianhyde/sqlline/wiki/Demos